### PR TITLE
Simple TowTruck support, keyboard shortcut only

### DIFF
--- a/public/javascripts/towtruckSupport.js
+++ b/public/javascripts/towtruckSupport.js
@@ -1,0 +1,2 @@
+// This enables alt-T alt-T to turn on TowTruck:
+var TowTruckConfig_enableShortcut = true;

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -9,6 +9,8 @@
 
     <script data-main="<%= process.env.ASSET_HOST%>/javascripts/requireConfig" src="/vendor/requirejs/require.js"></script>
     <script src="/components/components.js"></script>
+    <script src="/javascripts/towtruckSupport.js"></script>
+    <script src="https://towtruck.mozillalabs.com/towtruck.js"></script>
   </head>
   <body>
     <%- body %>


### PR DESCRIPTION
This enables the most trivial TowTruck support possible, including without any button in the interface.  No special customization is done with the appmaker itself (which means apps won't be sync'd).  Hitting `alt-T alt-T` will start TowTruck (invitees will have it started immediately).
