### PR TITLE
Scoped the css a bit better to fix a bug

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -534,7 +534,7 @@ button.log-toggle {
 	display: block;
 }
 
-.name {
+.editable-section .name {
 	font-size: 18px;
 	color: #fff;
 	font-weight: 400;


### PR DESCRIPTION
It was breaking something in a component. We should scope our CSS better in the designer to prevent unwanted CSS bleed.
