### PR TITLE
README updates (mongod), updated sample.env and more sane errors for mongoose.connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd mozilla-appmaker
 [Fork](https://help.github.com/articles/fork-a-repo) this repository, and
 then clone your fork into the `mozilla-appmaker` directory:
 ```
-git clone https://github.com/<your username>/appmaker.git appmaker
+git clone git@github.com:<your GitHub username>/appmaker.git appmaker
 ```
 
 Your directory structure should look like this:
@@ -53,7 +53,7 @@ mozilla-appmaker/
 Configure remote:
 ```
 cd appmaker
-remote add upstream https://github.com/mozilla-appmaker/appmaker.git
+remote add upstream git@github.com:mozilla-appmaker/appmaker.git
 git fetch upstream
 ```
 
@@ -71,6 +71,7 @@ cp sample.env .env
 
 A short explanation of a complete `.env` file:
 ```
+MONGO_URL: REQUIRED - the URI for your mongod instance and database, for example mongodb://localhost/appmakerdev (or whatever your database is named)
 COOKIE_SECRET: A long, complex string for cookie encryption (NOTE: You define this for your local use, the string can be anything).
 STORE: Storage approach for publishing apps. `local` is the default, `s3` requires additional environment variables (prefixed by S3_)
 S3_BUCKET: S3 bucket name. e.g. "my.coolappmaker.com"
@@ -80,6 +81,14 @@ S3_OBJECT_PREFIX: String to prepend S3 objects. Useful for storing objects in fo
 PUBLISH_URL_PREFIX: String to prepend to filenames that are saved when publishing. Try use the URL that matches the protocol from which assets are hosted to avoid mixed content blockage.
 PERSONA_AUDIENCE: The hostname and port of Appmaker used by Persona for authentication
 PORT: The port that the web process listens on for incomming connections
+```
+
+### Install and run MongoDB
+
+1. Install from MongoDB installation packages, brew, apt-get, etc
+2. Either configure MongoDB to run on startup or manually start the mongod daemon. You can also run mongod from foreman by adding it to your Procfile
+```
+mongod
 ```
 
 ### Start the Server
@@ -99,6 +108,9 @@ If you need foreman:
 ```
 sudo gem install foreman
 ```
+
+NOTE: foreman's configuration file is Procfile in the root of the appmaker directory
+Foreman explanation: http://blog.daviddollar.org/2011/05/06/introducing-foreman.html
 
 ## How you can help
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,7 +7,9 @@ var urls = require('../lib/urls');
 
 module.exports = function (store, viewsPath, urlManager, remixMailer, makeAPIPublisher) {
   var mongoose = require('mongoose');
-  var dbconn = mongoose.connect(process.env.MONGOLAB_URI || 'mongodb://localhost/appmakerdev');
+  var dbconn = mongoose.connect(process.env.MONGO_URI || 'mongodb://localhost/appmakerdev',function(err) {
+      if (err) throw new Error("Problem connecting to mongodb. Is mongod running? Is your database name correct?");
+  });
 
   return {
     index: function(req, res) {

--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,5 @@
-COOKIE_SECRET=I hate working as a janitor for arrogant rich people; so I clean their computer keyboareds with the toilet brush
+MONGO_URI=mongodb://localhost/appmakerdev
+COOKIE_SECRET=thisismyexamplesecretstring
 STORE=local
 S3_BUCKET=
 S3_KEY=


### PR DESCRIPTION
1. In README, changed github clone transport from https to ssh …
2. Added MONGO_URI to sample.env and noted in README that it’s required
3. Added note about needing mongod running to run app maker in README
4. Brief read me note about Procfile and foreman
