### PR TITLE
fix for capturing & firing CeciElementAdded

### DIFF
--- a/public/ceci/ceci-card-base.html
+++ b/public/ceci/ceci-card-base.html
@@ -53,17 +53,6 @@
   <script>
     Polymer('ceci-card-base', {
       ready: function () {
-        var that = this;
-        var observer = new MutationObserver(function (mutations) {
-          mutations.forEach(function (mutation) {
-            Array.prototype.forEach.call(mutation.addedNodes, function (addedNode) {
-              if (addedNode.localName.indexOf('ceci-') === 0) {
-                document.dispatchEvent(new CustomEvent('CeciElementAdded', {bubbles: true, detail: addedNode}));
-              }
-            });
-          });
-        });
-        observer.observe(this, { childList: true });
       },
       show: function () {
         this.setAttribute('visible', true);

--- a/public/ceci/ceci-element-base.html
+++ b/public/ceci/ceci-element-base.html
@@ -224,7 +224,7 @@
           }
         },
         enteredView: function () {
-          // dummy function to prevent a polymer super() loop (looks like a polymer bug)
+          document.dispatchEvent(new CustomEvent('CeciElementAdded', {bubbles: true, detail: this}));
         }
       });
     })();

--- a/public/designer/js/component-tray.js
+++ b/public/designer/js/component-tray.js
@@ -45,13 +45,6 @@ define(
           if (card) {
             var newElement = document.createElement(name);
             card.appendChild(newElement);
-            window.dispatchEvent(new CustomEvent(
-              'CeciElementAdded',
-              {
-                bubbles: true,
-                detail: newElement
-              }
-            ));
           }
         }, false);
 

--- a/public/designer/js/mutant.js
+++ b/public/designer/js/mutant.js
@@ -39,7 +39,6 @@ define(
         selectElement(element);
       });
       selectElement(element);
-      console.log(e);
     }, false);
   }
 );


### PR DESCRIPTION
1. Removed observer from ceci-card-base, since ceci-element-base's enteredView can do the same.
2. Removed duplicate dispatch of CeciElementAdded in component-tray after adding a component.
3. console.log cleanup.
