### PR TITLE
auto-populate components in COMPONENTS_DIR into layout.ejs.

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,6 +148,8 @@ routes = require('./routes')(
   makeAPIPublisher
 );
 
+app.locals.extraComponents = routes.proxy.findComponents();
+
 app.get('/', routes.index);
 
 app.all('/designer', routes.designer);

--- a/routes/proxy.js
+++ b/routes/proxy.js
@@ -51,6 +51,19 @@ module.exports = {
     });
   },
 
+  findComponents: function() {
+    var componentsDir = process.env["COMPONENTS_DIR"];
+
+    if (!componentsDir) return [];
+
+    return fs.readdirSync(componentsDir).filter(function(filename) {
+      return fs.existsSync(path.join(componentsDir, filename,
+                                     'component.html'));
+    }).map(function(name) {
+      return '/component/mozilla-appmaker/' + name + '/component.html';
+    });
+  },
+
   component: function(req, res) {
     var org = req.params.org;
     var component = req.params.component;

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -31,6 +31,10 @@
 
     <link rel="import" href="/ceci/ceci-channel-menu.html">
 
+    <% extraComponents.forEach(function(href) { %>
+    <link rel="import" href="<%= href %>">
+    <% }) %>
+
     <link rel="import" href="/component/mozilla-appmaker/component-button/component.html">
     <link rel="import" href="/component/mozilla-appmaker/component-chat-window/component.html">
     <link rel="import" href="/component/mozilla-appmaker/component-counter/component.html">


### PR DESCRIPTION
I am not a huge fan of this commit, and it violates DRY to some extent, but I tried putting all the code as close to the other proxying code as possible so that it doesn't get out-of-sync easily.

I suspect this will all be refactored and stuff once we decide on a more formal specification/schema for component filesystem structure.
