### PR TITLE
Remove the bower postinstall step from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "grunt-simple-mocha": "~0.4.0"
   },
   "scripts": {
-    "test": "grunt",
-    "postinstall": "./node_modules/.bin/bower install"
+    "test": "grunt"
   }
 }


### PR DESCRIPTION
We are already keeping `bower_components` in the repository so there's no need for it; also, programs like [appchef](https://github.com/toolness/appchef) that want to include appmaker as a dependency can't run bower as root (which is done when `npm -g` is used).
