### PR TITLE
Prevent defaults from always being added

### DIFF
--- a/public/ceci/ceci-element-base.html
+++ b/public/ceci/ceci-element-base.html
@@ -150,17 +150,19 @@
           var defaultListeners = processListeners(this.ceci.listeners, attributeResults.listeners);
           var defaultBroadcasts = processBroadcasts(this.ceci.broadcasts, ceciDefinition.broadcasts);
 
-          defaultListeners.forEach(function (d) {
-            if (!that.querySelector('ceci-listen[for="' + d.name + '"]')) {
-              that.setListener(d.name, d.channel);
-            }
-          });
+          this.applyDefaults = function () {
+            defaultListeners.forEach(function (d) {
+              if (!that.querySelector('ceci-listen[for="' + d.name + '"]')) {
+                that.setListener(d.name, d.channel);
+              }
+            });
 
-          defaultBroadcasts.forEach(function (d) {
-            if (!that.querySelector('ceci-broadcast[from="' + d.name + '"]')) {
-              that.setBroadcast(d.name, d.channel);
-            }
-          });
+            defaultBroadcasts.forEach(function (d) {
+              if (!that.querySelector('ceci-broadcast[from="' + d.name + '"]')) {
+                that.setBroadcast(d.name, d.channel);
+              }
+            });
+          };
 
           this.ceci.thumbnail = ceciDefinition.thumbnail;
           this.ceci.tags = ceciDefinition.tags;
@@ -168,7 +170,6 @@
           this.ceci.attributes = ceciDefinition.attributes;
 
           that.localized();
-
         },
         broadcast: function (name, data) {
           var broadcastElement = this.querySelector('ceci-broadcast[from="' + name + '"]');

--- a/public/designer/js/component-tray.js
+++ b/public/designer/js/component-tray.js
@@ -45,6 +45,7 @@ define(
           if (card) {
             var newElement = document.createElement(name);
             card.appendChild(newElement);
+            newElement.applyDefaults();
           }
         }, false);
 


### PR DESCRIPTION
1. Moved default listener & broadcast addition to its own function.
2. applDefaults called from component-tray after adding component to DOM.
