### PR TITLE
bug1126 - i18n prevents proper web server bootup

### DIFF
--- a/app.js
+++ b/app.js
@@ -226,7 +226,7 @@ if (!module.parent) {
   components.load(function(components) {
     app.locals.components = components;
     localeBuild(components, i18n.getSupportLanguages(), function(map) {
-      i18n.addLocaleObject(map, function(bool) {
+      i18n.addLocaleObject(map, function(err, bool) {
         if(bool) {
           http.createServer(app).listen(app.get('port'), function(){
             console.log("Express server listening on port " + app.get('port'));


### PR DESCRIPTION
Added `err` to callback params in i18n callback in app.js.
