### PR TITLE
Feature 1070 - Component name in editables panel

### DIFF
--- a/public/ceci/ceci-element-base.html
+++ b/public/ceci/ceci-element-base.html
@@ -172,6 +172,8 @@
 
           this.ceci.attributes = ceciDefinition.attributes || {};
 
+          this.ceci.name = this.gettext(this.localName) || this.ceciDefinition.name || this.localName;
+
           that.localized();
         },
         broadcast: function (name, data) {

--- a/public/designer/js/editable.js
+++ b/public/designer/js/editable.js
@@ -166,6 +166,8 @@ define(['inflector', 'l10n', 'colorpicker.core'], function (Inflector, L10n) {
       $(".editable-attributes").html("");
     },
     displayAttributes: function (element) {
+      $(".editable-header > .name").html(element.ceci.name);
+
       var attributeList = $(".editable-attributes");
 
       attributeList.html("");


### PR DESCRIPTION
1. Added localized name property to ceci descriptor attached to elements.
2. Injected name into existing name header in the editables panel.
