### PR TITLE
Only use localeBuilder for en-US

### DIFF
--- a/app.js
+++ b/app.js
@@ -225,9 +225,9 @@ if (!module.parent) {
   // Load components from various sources
   components.load(function(components) {
     app.locals.components = components;
-    localeBuild(components, i18n.getSupportLanguages(), function(map) {
-      i18n.addLocaleObject(map, function(err, bool) {
-        if(bool) {
+    localeBuild(components, ['en-US'], function(map) {
+      i18n.addLocaleObject(map, function(err) {
+        if(!err) {
           http.createServer(app).listen(app.get('port'), function(){
             console.log("Express server listening on port " + app.get('port'));
           });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "statsd": "0.6.0",
     "tmp": "~0.0.23",
     "webmaker-download-locales": "0.1.2",
-    "webmaker-i18n": "0.3.15",
+    "webmaker-i18n": "0.3.17",
     "webmaker-locale-mapping": "latest"
   },
   "engines": {


### PR DESCRIPTION
This pull request will now stop using localeBuilder to load other
translation files from components and instead use
webmaker-download-locales which has been merged previously and we can
take advantage of that which will help reduce amount of making request
to get translation files.
