### PR TITLE
removing some dead code around createURLPrefix

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -28,12 +28,7 @@ module.exports = function (store, viewsPath, urlManager, remixMailer, makeAPIPub
     },
 
     designer: function (req, res) {
-      var publishUrl = urlManager.createURLPrefix('{remixName}');
-
-      res.render('designer', {
-        htmlInjection: '',
-        publishUrl: publishUrl
-      });
+      res.render('designer');
     },
 
     remix: function (req, res) {


### PR DESCRIPTION
I am pretty sure this is not being used anymore. I tried to find some use for it, but couldn't.

Thoughts?

My goal here is to simplyfy the code around urls and publishing, so future changes I am making in publishing is much safer. It feels a bit hairy right now. If I can trim the createURLPrefix usage a bit, I can make safe simple changes to it. (and understand it better)
