### PR TITLE
fix #1312 Send app name to makeapi and not the crazy random string

### DIFF
--- a/routes/publish.js
+++ b/routes/publish.js
@@ -154,8 +154,8 @@ module.exports = function (store, viewsPath, urlManager, makeAPIPublisher, dbcon
                   remix: remoteURLs.app,
                   thumbnail: 'http://appmaker.mozillalabs.com/images/mail-man.png',
                   tags: ['appmaker'],
-                  description: 'Appmaker ' + folderName,
-                  title: 'Appmaker ' + folderName,
+                  description: 'Appmaker ' + appName,
+                  title: appName,
                   email: req.session.email,
                   author: userName,
                   locale: req.localeInfo.lang


### PR DESCRIPTION
STRs to test:
- [ ] run webmaker.org https://github.com/mozilla/webmaker.org
- [ ] run login.webmaker.org https://github.com/mozilla/login.webmaker.org
- [ ] run MakeAPI https://github.com/mozilla/MakeAPI
- [ ] publish (and save) an app
- [ ] Navigate to http://localhost:7777/en-US/me

Expected: The app name in the my makes gallery should show the apps' name, not the crazy url name.
