### PR TITLE
Ceci-element-designer bugfix.

### DIFF
--- a/public/designer/components/ceci-element-designer.html
+++ b/public/designer/components/ceci-element-designer.html
@@ -59,15 +59,6 @@
           handle.className = 'handle cecidesigner';
           this.appendChild(handle);
         }
-
-        // ensure correct channel visualisation
-        ["broadcast", "listen"].forEach(function(type) {
-          var vis = that.querySelector("ceci-"+type+"-vis");
-          var elements = that.querySelectorAll("ceci-"+type);
-          if(elements.length > 0) {
-            vis.updateChannelVis(elements);
-          }
-        });
       }
     });
   </script>


### PR DESCRIPTION
The removed chunk of code was throwing js errors on saved apps, and also seems redundant, as updateChannelVis gets fired when it is needed anyway.
