### PR TITLE
autogenerated channels now

### DIFF
--- a/public/ceci/ceci-channel-menu.html
+++ b/public/ceci/ceci-channel-menu.html
@@ -35,7 +35,7 @@
           this.super();
           this.menuStructure = this.shadowRoot.querySelector("content");
         },
-        buildMenuHTML: function(menu) {
+        buildMenuHTML: function() {
           var menu = this.shadowRoot.querySelector(".color-ui");
           var record = allChannels.length === 0;
           channels.forEach(function(channel) {


### PR DESCRIPTION
this build all possible channels that can be used during design work based on a cross matrix of channel names (blue, green, etc), and channel variants (one, two, three). If we want more channels, it's now super easy to add more. CSS notwithstanding.

Also creates a window.CeciChannels that can be tapped into by other components to figure out which channels the designer says can be used
