### PR TITLE
Search functionality in designer is BACK!

### DIFF
--- a/public/ceci/ceci-designer.js
+++ b/public/ceci/ceci-designer.js
@@ -22,8 +22,6 @@ define([], function() {
     "ceci-channel-map"
   ];
 
-  var knownComponents = [];
-
   // Because of the way requirejs works, this is a singleton.
   var CeciDesigner = {
     // It's expected that the channel object being sent has a .id to uniquely identify it.
@@ -53,9 +51,8 @@ define([], function() {
       var components = [];
       for (var tagName in window.CeciDefinitions) {
         if (BUILT_IN_COMPONENTS.indexOf(tagName) === -1) {
-          if (CeciDesigner.getCeciDefinitionScript(tagName) && knownComponents.indexOf(tagName) === -1) {
+          if (CeciDesigner.getCeciDefinitionScript(tagName)) {
             components.push(tagName);
-            knownComponents.push(tagName);
           }
         }
       }

--- a/public/designer/js/component-tray.js
+++ b/public/designer/js/component-tray.js
@@ -83,6 +83,44 @@ define(
 
     window.addEventListener("polymer-ready", function () {
       DesignerTray.addComponentsFromRegistry();
+
+      var searchBox = document.querySelector('.component-search');
+      searchBox.addEventListener('keyup', function (e) {
+        var searchValue = searchBox.value.trim().toLowerCase();
+        var componentsContainer = document.querySelector('#components');
+
+        if (searchValue.length > 0) {
+          CeciDesigner.forEachComponent(function (componentTag) {
+            var menuElement = componentsContainer.querySelector('designer-component-tray-item[name="' + componentTag + '"]');
+
+            if (window.CeciDefinitions[componentTag] && menuElement) {
+              var tags = window.CeciDefinitions[componentTag].tags || [];
+              var found = false;
+
+              var stringsToSearch = typeof tags === 'string' ? [tags] : tags;
+              stringsToSearch.push(componentTag.toLowerCase());
+              window.CeciDefinitions[componentTag].name && stringsToSearch.push(window.CeciDefinitions[componentTag].name.toLowerCase());
+              window.CeciDefinitions[componentTag].description && stringsToSearch.push(window.CeciDefinitions[componentTag].description.toLowerCase());
+
+              stringsToSearch.forEach(function (string) {
+                found = found || string.toLowerCase().indexOf(searchValue) > -1;
+              });
+
+              if (!found) {
+                menuElement.classList.add('hide');
+              }
+              else {
+                menuElement.classList.remove('hide');
+              }
+            }
+          });
+        }
+        else {
+          Array.prototype.forEach.call(componentsContainer.querySelectorAll('designer-component-tray-item'), function (e) {
+            e.classList.remove('hide');
+          });
+        }
+      });
     });
 
     return DesignerTray;

--- a/public/stylesheets/designer-component-tray-item.less
+++ b/public/stylesheets/designer-component-tray-item.less
@@ -3,9 +3,14 @@
 @import "webfonts.less";
 
 :host {
-    font-family: "Source Sans Pro", arial;
-    font-size: 14px;
-    color: #31353C;
+  font-family: "Source Sans Pro", arial;
+  font-size: 14px;
+  color: #31353C;
+  display: block;
+}
+
+:host(.hide) {
+  display: none;
 }
 
 .component-card {

--- a/views/designerHTML.ejs
+++ b/views/designerHTML.ejs
@@ -31,7 +31,7 @@
     <div class="expand-handle"></div>
     <div class="component-filtering">
       <div class="modal-header">
-        <input type="text" class="component-search" placeholder="<%- gettext("Search by name or tag...") %>" />
+        <input type="text" class="component-search" placeholder="<%- gettext("Search by name, tag, or description...") %>" />
       </div>
       <div class="component-tags-wrapper">
         <span class="component-tags"></span>


### PR DESCRIPTION
1. Removed "knownComponents" from ceci-designer. Redundant in component-tray.
2. Fixed placeholder for component-search box.
3. display:block and "hide" class for designer-component-tray-item.
4. Search functionality, using component name, label, tags, description.
