### PR TITLE
Menu Channel Icon Font-Size Fix

### DIFF
--- a/public/stylesheets/broadcast-menu.less
+++ b/public/stylesheets/broadcast-menu.less
@@ -222,6 +222,7 @@
       overflow:hidden;
       padding: 0px 6px 1px 6px;
       opacity: .4;
+      font-size: 1.3rem;
       .border-radius(20px);
 
       &:hover {


### PR DESCRIPTION
Fixed channel icon font size. It wasn't set so component styles were affecting it.
