### PR TITLE
Select brick when channel menu opened.

### DIFF
--- a/public/designer/components/ceci-channel-menu.html
+++ b/public/designer/components/ceci-channel-menu.html
@@ -80,6 +80,7 @@
           this.super();
           this.menuStructure = this.shadowRoot.querySelector("content");
           this.addEventListener("click", function(e) {
+            window.dispatchEvent(new CustomEvent("SelectElement", { detail :  this.component }));
             e.stopPropagation();
           });
         },

--- a/public/designer/js/mutant.js
+++ b/public/designer/js/mutant.js
@@ -47,6 +47,10 @@ define(
       selectElement(e.detail);
     });
 
+    window.addEventListener('SelectElement', function (e) {
+      selectElement(e.detail);
+    });
+
     return {
       selectElement: selectElement
     };


### PR DESCRIPTION
Fixes a bug where brick wasn't being selected when its channel menu was opened.

Fixes #1528
Fixes #1531
