### PR TITLE
removing border radius from internal progress bar

### DIFF
--- a/public/stylesheets/loading.css
+++ b/public/stylesheets/loading.css
@@ -34,13 +34,13 @@
   border-radius: 4px;
   top: 50%;
   background: linear-gradient( 90deg, #3fb58e, #ffcd36, #27aae1 );
+  overflow: hidden;
 }
 
 .loading-cover {
   background-color: #31353C;
   height: 100%;
   width: 100%;
-  border-radius: 4px;
   right: 0;
   position: absolute;
   transition: width .2s linear;


### PR DESCRIPTION
Nothing big, I just noticed while loading the progress bar had some border radius inside it. Need to be quick to catch it (or comment some code to choke off the load).

![borderradius](https://cloud.githubusercontent.com/assets/197334/3483139/92043fca-038a-11e4-8ac2-bf3c16e70f4b.png)

The border radius was there for either side, but only when it was full and not for partial loads.

I fixed it by instead removing the border radius on the progress and telling the container to hide overflow.
