### PR TITLE
fixes #1421 Hide remix link button while on a phone

### DIFF
--- a/locale/en_US/msg.json
+++ b/locale/en_US/msg.json
@@ -97,7 +97,6 @@
   "Need qualified URL": "Components needs a fully qualified URL, including the http/https protocol prefix",
   "New App": "New App",
   "opinionDesc": "Then we'd love your feedback! Fill out our short Usability Survey while <a href=\"\">building an app</a> and we'll use your feedback to improve Appmaker.",
-  "or": "or",
   "Page": "Page",
   "Project": "Project",
   "Publish": "Publish",

--- a/public/stylesheets/remix.css
+++ b/public/stylesheets/remix.css
@@ -50,7 +50,6 @@ button.remix-button {
   -moz-appearance: none;
   border: none;
   width: 100%;
-  display: block;
   border-radius: 2px;
   box-sizing:border-box;
   -moz-box-sizing:border-box; /* Firefox */
@@ -64,6 +63,10 @@ button.remix-button {
 
 button.remix-button:hover {
   background: #3f9fe8;
+}
+
+.hidden {
+  display: none;
 }
 
 button.remix-button:active {

--- a/views/remixpane.ejs
+++ b/views/remixpane.ejs
@@ -2,11 +2,10 @@
       <div id="remix-icon"></div>
       <div id="remix-panel">
         <button id="close-remix-panel"></button>
-        <div id="remix-panel-content" class="hidden">
+        <div id="remix-panel-content">
           <div id="remix-panel-inner">
             <input type="email" id="remix-panel-email" placeholder="Your Email">
             <button id="remix-button" class="remix-button"><%- gettext("Mail me the remix link") %></button>
-            <div class="centered"><%- gettext("or") %></div>
             <button id="remix-now-button" class="remix-button"><%- gettext("Remix now") %></button>
             <div class="remix-explanation">
               <%- gettext("remixExplaination") %>
@@ -18,13 +17,11 @@
         (function(){
           var open = document.getElementById('remix-icon');
           var panel = document.getElementById('remix-panel');
-          var content = document.getElementById('remix-panel-content');
           var close = document.getElementById('close-remix-panel');
           var email = document.getElementById('remix-panel-email');
 
           open.onclick = function (e) {
             panel.classList.add('expanded');
-            content.classList.remove('hidden');
             open.classList.add('hidden');
             remixButton.disabled = false;
             email.disabled = false;
@@ -35,7 +32,6 @@
 
           function closeRemixPanel (e) {
             panel.classList.remove('expanded');
-            content.classList.add('hidden');
             open.classList.remove('hidden');
           }
 
@@ -62,10 +58,13 @@
           };
 
           var remixNowButton = document.querySelector("#remix-now-button");
-          remixNowButton.onclick = function (e) {
-            var remixURL = '<%= process.env.ASSET_HOST %>/remix?app=<%- remixURL %>';
-            window.open(remixURL);
-          };
+          if ('ontouchstart' in window) {
+            remixNowButton.classList.add('hidden');
+          } else {
+            remixNowButton.onclick = function (e) {
+              window.open('<%= process.env.ASSET_HOST %>/remix?app=<%- remixURL %>');
+            };
+          }
 
         })();
       </script>


### PR DESCRIPTION
The "Remix Now" button only takes you to the remix rul while on a desktop.

I also removed the "or" text between the buttons as I found it unnecessary and getting in the way.
