### PR TITLE
No more Times New Roman on desktop.

### DIFF
--- a/public/stylesheets/app.less
+++ b/public/stylesheets/app.less
@@ -3,7 +3,7 @@ html, body {
   padding: 0;
   border: 0;
   font-size: 62.5%;
-  font-family: "Helvetica Neue", sans-serif;
+  font-family: "Helvetica Neue", Helvetica, sans-serif;
 }
 
 html {


### PR DESCRIPTION
Looks like FFOS defaults to Fira anyway, so don't need to declare it explicitly.
Will look into Android next to see how to render things in Roboto, which is their default.
