### PR TITLE
fixes #1672 remove dead left class

### DIFF
--- a/public/stylesheets/style.less
+++ b/public/stylesheets/style.less
@@ -57,10 +57,6 @@ textarea {
    height:0
 }
 
-.left {
-  float: left;
-}
-
 a {
   text-decoration: none;
 }


### PR DESCRIPTION
The class left was used in the jazz hands and in our gobal css to do different things.

In firefox the jazzhands picked up on the global left class.

I looked up and down for where the left class is used, and I could not find it.

I found one spot in the landing page, but it had it's own left class declared in site.less, so, that wasn't it. I think it's a dead class and we should just remove it.
