### PR TITLE
fixes #1700 clear search box if new category is selected

### DIFF
--- a/public/designer/js/component-tray.js
+++ b/public/designer/js/component-tray.js
@@ -264,7 +264,7 @@ define(
 
           option.addEventListener("click",function(e){
             document.querySelector('.component-search').value = "";
-            doSearch("");
+            doSearch();
             that.filterCategory(e.target.getAttribute("data-category"));
           });
         }


### PR DESCRIPTION
Fixes #1700 
Looks like a lot more changes than it is, I mainly just moved code from inside an event to a defined function that can be called elsewhere.
