### PR TITLE
Ceci-pressdown/pressup event listener adding bug fix.

### DIFF
--- a/public/ceci/ceci-element-base.html
+++ b/public/ceci/ceci-element-base.html
@@ -272,7 +272,7 @@
           var mapEntry = customListenerMap[listener];
 
           // Check if we've already added that listener
-          if(that.eventListeners.indexOf(mapEntry) < 0 && mapEntry) {
+          if(mapEntry && that.eventListeners.indexOf(mapEntry) < 0) {
             that.eventListeners.push(mapEntry);
             // Fire an event directly at the element with the on-ceci-* attribute
             el.addEventListener(mapEntry[that.touchEnabled ? 'mobile' : 'desktop'], function(e){


### PR DESCRIPTION
Fixes a bug where we would add the 'on-ceci-pressdown/pressup' listeners every time 'attached' was fired (like after sorting a component in the designer) causing buttons to fire multiple "click" signals every time they were pressed.

Fixes #1917
