### PR TITLE
Brick placement update when adding

### DIFF
--- a/public/designer/js/component-tray.js
+++ b/public/designer/js/component-tray.js
@@ -147,17 +147,12 @@ define(
           // wait until Polymer has prepared the element completely
           newElement.async(function() {
             var selectedBrick = card.querySelector(".brick.selected");
-            if(selectedBrick){
-              var next = selectedBrick.nextSibling;
-              if(next){
-                card.insertBefore(newElement,next);
-              } else {
-                card.appendChild(newElement);
-              }
+            var next = selectedBrick ? selectedBrick.nextSibling : false;
+            if(selectedBrick && next){
+              card.insertBefore(newElement,next);
             } else {
               card.appendChild(newElement);
             }
-
             // Apply defaults here explicitly so that element doesn't
             // have to figure out whether or not it's new when it's
             // attached to the DOM.


### PR DESCRIPTION
When you add a brick from the tray, it places it after the currently selected brick (if there is a selected brick).

Closes #1907
