### PR TITLE
Showing "Other" bricks in development.

### DIFF
--- a/public/designer/js/component-tray.js
+++ b/public/designer/js/component-tray.js
@@ -188,11 +188,12 @@ define(
               }
             }
           }
-          //Means it wasn't in any categories
-          if(!added){
-            // var item = DesignerTray.buildItem(name);
-            // DesignerTray.showCategory("other");
-            // document.querySelector(".category-container.other").appendChild(item);
+
+          //If it's not in any categories and we're in devmode, let's show it!
+          if(!added && DesignerTray.devmode == true){
+            var item = DesignerTray.buildItem(name);
+            DesignerTray.showCategory("other");
+            document.querySelector(".category-container.other").appendChild(item);
           }
           knownComponents.push(name);
         }
@@ -381,6 +382,7 @@ define(
     }
 
     function onPolymerReady() {
+      DesignerTray.devmode = document.querySelector("#components-wrapper").classList.contains("development");
       DesignerTray.addComponentsFromRegistry();
       var searchBox = document.querySelector('.component-search');
       searchBox.addEventListener('keyup', function() {

--- a/views/designerHTML.ejs
+++ b/views/designerHTML.ejs
@@ -18,8 +18,7 @@
       </div>
     </div>
     <div class="brick-category"></div>
-
-    <div id="components-wrapper">
+    <div id="components-wrapper" <% if (!process.env.PRODUCTION) { %>class="development"<% } %> >
       <div id="category-description"></div>
       <div id="components"></div>
     </div>


### PR DESCRIPTION
Added a `PRODUCTION=` variable. If left blank, bricks that aren't in a category will show up in the "Other" category, which is useful for development. If set to `true` only categorized bricks will show.

Closes #1979 
