### PR TITLE
different gettext route for ontology strings

### DIFF
--- a/public/ceci/ceci-element-base.html
+++ b/public/ceci/ceci-element-base.html
@@ -233,7 +233,7 @@
             // we're using get/setAttribute because at this point that[key] is not guaranteed to work yet.
             if (!that.getAttribute(key)) {
               var lkey = that.localName + "/attributes/" + key;
-              var lstring = that.gettext(lkey);
+              var lstring = that.getpropertytext(lkey);
               that.setAttribute(key, lstring);
             }
           });
@@ -379,6 +379,20 @@
       domReady: function () {
         document.dispatchEvent(new CustomEvent('CeciElementAdded', {bubbles: true, detail: this}));
       },
+      /**
+       * localise things based on their ontological path, like "ceci-element/attributes/description"
+       * This should never give back the original string as acceptable localised string, and will
+       * instead generate "" if there is no appropriate locale string found.
+       */
+      getpropertytext: function(keyname) {
+        var localized = this.gettext(keyname);
+        return (localized === keyname) ? "" : localized;
+      },
+      /**
+       * localise things based on human text. Both input and output to this function should be human-
+       * readable text, so that if no localised string exists, the original human-readable text is
+       * simply sent back.
+       */
       gettext: function (keyname) {
         return this.L10n.get(keyname);
       }


### PR DESCRIPTION
gettext is human-string in, human-string out, we're abusing that for properties like "ceci-element/attributes/monkeys/description", where we shouldn't ever see that string as a viable locale string when no other locals have it, or it's hardcoded to `""` =)
