### PR TITLE
Timer sound fix.

### DIFF
--- a/public/bundles/components/component-timer/component.html
+++ b/public/bundles/components/component-timer/component.html
@@ -133,6 +133,10 @@ background="#222">
         this._timeLeft = this.time * 1000;
         this._timeLeftString = timeFromSeconds(this._timeLeft);
       },
+      detached : function(){
+        this.super();
+        this.running = false;
+      },
       start: function() {
         if(!this.running) {
           this._startTime = Date.now();
@@ -158,8 +162,8 @@ background="#222">
         var that = this;
 
         requestAnimationFrame(function(){
-          if(that.running == true) {
 
+          if(that.running == true) {
             that._elapsedTime = Date.now() - that.timeStamp;
             that._timeLeft = that._timeLeft - that._elapsedTime;
 


### PR DESCRIPTION
Timer no longer emits a "ding" after deleting it while it's running.

STR
- add a timer brick
- tap it to start the timer
- it will ding when finished
- tap it again
- before it finishes, delete the brick
- there will be no ding
