### PR TITLE
Sound brick updates

### DIFF
--- a/public/bundles/components/component-cowbell/component.html
+++ b/public/bundles/components/component-cowbell/component.html
@@ -26,7 +26,8 @@
           "label": "Volume",
           "editable": "number",
           "min" : 0,
-          "max" : 1
+          "max" : 1,
+          "step" : ".1"
         },
         "bellcolor": {
           "label": "Cowbell Color",
@@ -51,7 +52,7 @@
         this.loadSound("cowbell","sounds/sound.mp3");
       },
       kickon: function () {
-        this.playSound("cowbell",.4);
+        this.playSound("cowbell",this.volume);
         this.$.wrapper.classList.add("hit");
       },
       kick : function(){

--- a/public/bundles/components/component-kickdrum/component.html
+++ b/public/bundles/components/component-kickdrum/component.html
@@ -27,7 +27,8 @@
           "label": "Volume",
           "editable": "number",
           "min" : 0,
-          "max" : 1
+          "max" : 1,
+          "step" : ".1"
         },
         "backgroundcolor": {
           "label": "Background Color",
@@ -61,7 +62,7 @@
         this.loadSound("kick","sounds/kick.ogg");
       },
       kickon: function (e) {
-        this.playSound("kick",.4);
+        this.playSound("kick",this.volume);
         this.$.kick.classList.add("on");
       },
       kick : function(){

--- a/public/bundles/components/component-snaredrum/component.html
+++ b/public/bundles/components/component-snaredrum/component.html
@@ -27,7 +27,8 @@
           "label": "Volume",
           "editable": "number",
           "min" : 0,
-          "max" : 1
+          "max" : 1,
+          "step" : ".1"
         },
         "backgroundcolor": {
           "label": "Background Color",


### PR DESCRIPTION
- These bricks now use a .1 increment for the volume editable
- They also actually use their volume editable to control the volume

STR
- add any / all of these to an app
- volume editable for all of them should increment by .1 when using the little arrows on the input field
- the volume editable actually controls the volume of these bricks

Partly fixes #1961 - can you comment on that one @Pomax ?
