### PR TITLE
Fixes install button showing when it shouldn't bug.

### DIFF
--- a/public/stylesheets/install.less
+++ b/public/stylesheets/install.less
@@ -25,6 +25,10 @@ p {
   line-height: 140%;
 }
 
+.mode-canrun, .mode-caninstall, .mode-cantinstall {
+  display: none;
+}
+
 @media (max-width: 310px)  {
   html {
     background: black;


### PR DESCRIPTION
STS (steps to test)
- Publish an app
- Follow the link to the app's /install page
  - On installable platforms `Install App` button is visible (ie Firefox)
  - On non-installable platforms, it isn't (ie Chrome)

Also addresses installable platforms showing when appropriate.

Fixes #2028 
