### PR TITLE
Fixed non-working microphone start/stop listeners

### DIFF
--- a/public/bundles/components/component-microphone-button/component.html
+++ b/public/bundles/components/component-microphone-button/component.html
@@ -4,23 +4,23 @@
     {
       "tags": ["microphone", "button", "audio"],
       "thumbnail": "./thumbnail.png",
-      "description": "Records sounds.",
+      "description": "Records sounds with your device microphone.",
       "name": "Microphone",
       "broadcasts": {
         "clip": {
-          "label": "clip",
+          "label": "Recorded Clip",
           "description": "An audio clip from your microphone.",
           "default": true
         }
       },
       "listeners": {
-        "start": {
+        "startRecording": {
           "description": "Start a microphone recording.",
-          "label": "start"
+          "label": "Start Recording"
         },
-        "stop": {
+        "stopRecording": {
           "description": "Stop a microphone recording.",
-          "label": "stop"
+          "label": "Stop Recording"
         }
       },
       "attributes": {}
@@ -104,6 +104,21 @@
       /**
        * WebRTC fallback due to lack of native WebAudio API support
        */
+      startRecording : function(){
+        this.recordRTC.startRecording();
+        this.startButton.classList.add("recording");
+        this.recording = true;
+      },
+      stopRecording : function(){
+        if (!this.recording) return;
+        var that = this;
+        this.recordRTC.stopRecording(function(audioURL) {
+          that.recording = false;
+          that.broadcast('clip', audioURL);
+          that.bg.style.background = that.buttoncolor;
+          that.startButton.classList.remove("recording");
+        });
+      },
       setupRecordRTC: function() {
         var that = this;
         var recordRTC;
@@ -111,22 +126,14 @@
         function loadupRecordingFunctionality() {
 
           var onbind = function(stream) {
-            recordRTC = RecordRTC(stream);
+            that.recordRTC = RecordRTC(stream);
 
             that.startButton.onclick = function() {
-              recordRTC.startRecording();
-              that.startButton.classList.add("recording");
-              that.recording = true;
+              that.startRecording();
             };
 
             that.stopButton.onclick = function() {
-              if (!that.recording) return;
-              recordRTC.stopRecording(function(audioURL) {
-                that.recording = false;
-                that.broadcast('clip', audioURL);
-                that.bg.style.background = that.buttoncolor;
-                that.startButton.classList.remove("recording");
-              });
+              that.stopRecording();
             };
           };
 

--- a/public/bundles/components/component-microphone-button/locale/en-US.json
+++ b/public/bundles/components/component-microphone-button/locale/en-US.json
@@ -1,11 +1,11 @@
 {
-  "ceci-microphone-button/description": "Records sounds.",
+  "ceci-microphone-button/description": "Records sounds with your device microphone.",
   "ceci-microphone-button/name": "Microphone",
-  "ceci-microphone-button/clip/label": "clip",
+  "ceci-microphone-button/clip/label": "Recorded Clip",
   "ceci-microphone-button/clip/description": "An audio clip from your microphone.",
-  "ceci-microphone-button/start/description": "Start a microphone recording.",
-  "ceci-microphone-button/start/label": "start",
-  "ceci-microphone-button/stop/description": "Stop a microphone recording.",
-  "ceci-microphone-button/stop/label": "stop",
+  "ceci-microphone-button/startRecording/description": "Start a microphone recording.",
+  "ceci-microphone-button/startRecording/label": "Start Recording",
+  "ceci-microphone-button/stopRecording/description": "Stop a microphone recording.",
+  "ceci-microphone-button/stopRecording/label": "Stop Recording",
   "your browser does not support recording":"your browser does not support microphone recording using the WebAudio MediaRecorder."
 }


### PR DESCRIPTION
STS (steps to test)
- Add Microphone brick
- Connect a button to each of the "Start Recording" and "Stop Recording" listeners
- Microphone will start and stop as desired when using the buttons

Fixes #1802
