### PR TITLE
Fixed the /app width

### DIFF
--- a/public/stylesheets/mobile.less
+++ b/public/stylesheets/mobile.less
@@ -112,7 +112,7 @@ a {
   }
 
   .app {
-    margin: 0 auto 0 auto;
+    margin: 0 auto;
     width: 340px;
     border: solid 15px rgba(0,0,0,.4);
     -webkit-border-radius: 10px;


### PR DESCRIPTION
When viewing a published /app on a desktop browser, the app is now 310px wide, as expected.

STT
- Create an app
- Publish it
- View it as a web app
- Inspect the app and confirm it is 310px wide

Fixes #2072 
