### PR TITLE
don't updateChannels if the details say the component died

### DIFF
--- a/public/ceci/ceci-broadcast.html
+++ b/public/ceci/ceci-broadcast.html
@@ -21,10 +21,11 @@
         this.updated();
       },
       detached: function(){
-        this.updated();
+        this.updated("detached");
       },
-      updated: function(){
-        window.dispatchEvent(new CustomEvent('channelUpdate'));
+      updated: function(action){
+        var details = { action: action };
+        window.dispatchEvent(new CustomEvent('channelUpdate', { detail: details } ));
       },
       attached: function () {
         this.updated();

--- a/public/designer/components/ceci-channel-map.html
+++ b/public/designer/components/ceci-channel-map.html
@@ -10,8 +10,13 @@
         this.listenerchannels = this.listenerchannels || [];
         this.channelNames = Object.keys(this.channels);
         var that = this;
-        this.onChannelUpdate = function() {
-          that.getChannels();
+        this.onChannelUpdate = function(evt) {
+          var details = evt.detail;
+          if(details && details.action && details.action === "detached") {
+            // end of the line for this component, no need to actually update
+            return;
+          }
+          that.getChannels(evt.detail);
         };
         window.addEventListener('channelUpdate', this.onChannelUpdate);
       },


### PR DESCRIPTION
we're not actually checking what the "trigger" for updateChannels is right now, so when we call it due to a component detach, it still tries to update the channels, despite those having just been destroyed.

fixes #1845 

STR:
- make an app with some bricks
- hit "new app"
- no JS errors (as seen in 1845)
