### PR TITLE
broadcast popup labels and event data now have the trigger name if there is no real data to show

### DIFF
--- a/public/ceci/ceci-element-base.html
+++ b/public/ceci/ceci-element-base.html
@@ -292,7 +292,7 @@
       broadcast: function (name, data) {
         var broadcastElement = this.querySelector('ceci-broadcast[from="' + name + '"]');
         if (broadcastElement) {
-          data = data || name;
+          data = data || this.gettext(this.localName + "-component/attributes/" + name) || name;
           broadcastElement.fire(data);
         }
       },

--- a/public/designer/components/ceci-element-designer.html
+++ b/public/designer/components/ceci-element-designer.html
@@ -27,7 +27,7 @@
           var broadcastDetails = {
             channel : broadcastElement.on,
             handler : name,
-            data: data ? data : name
+            data: data ? data : this.gettext(this.localName + "-component/attributes/" + name) || name
           };
           this.dispatchEvent(new CustomEvent('broadcastFired', {name: name, bubbles: true, detail: broadcastDetails}));
         }


### PR DESCRIPTION
fixes #1631

STR: new app, add media player, a button hooked up to media-listen:play, a counter hooked up to media-broadcast:playing

when you hit the button, right now the broadcast and listen bubbles show "undefined". With the patch, they will both say "playing"
