### PR TITLE
Channel menu not showing bug fix

### DIFF
--- a/public/designer/components/ceci-channel-menu.html
+++ b/public/designer/components/ceci-channel-menu.html
@@ -30,7 +30,6 @@
         menubuilt : false,
         ready : function (){
           this.addEventListener("click", function(e) {
-            window.dispatchEvent(new CustomEvent("SelectElement", { detail :  this.component }));
             e.stopPropagation();
           });
         },


### PR DESCRIPTION
STR
- Add a brick
- click it's channel menu icon
- it should open

Before patch: doesn't open
