### PR TITLE
replaced .error with .warn to prevent foreman crashing

### DIFF
--- a/lib/localeBuild.js
+++ b/lib/localeBuild.js
@@ -30,7 +30,7 @@ module.exports = function (components, locales, callback) {
             });
             success++;
           } catch(e) {
-            console.error("could not parse locale strings from "+localise);
+            console.warn("could not parse locale strings from "+localise);
             failed++;
           }
         }

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -22,7 +22,7 @@ function postmarkObject(email, subject, body) {
 function sendHandler(callback) {
   return function(err, result) {
     if(err) {
-      console.error("Unable to send via postmark: " + err.message);
+      console.warn("Unable to send via postmark: " + err.message);
       return callback(err, result);
     }
     console.info("Sent to postmark for delivery");

--- a/routes/component-registry.js
+++ b/routes/component-registry.js
@@ -57,7 +57,7 @@ module.exports = function (mongoose, dbconn) {
       var newComponent = new Component(compObj);
       newComponent.save(function(err, component){
         if (err){
-          console.error('saving new component failed');
+          console.warn('saving new component failed');
           return res.json(500, {error: 'Component was not saved due to ' + err});
         }
         // console.log("component added %j: ", component);
@@ -79,7 +79,7 @@ module.exports = function (mongoose, dbconn) {
       Component.findByIdAndUpdate(req.params.id || req.body._id, {
         $set: compObj}, {upsert:true}, function (err, user) {
           if (err){
-            console.error('saving modified component failed: ' + err);
+            console.warn('saving modified component failed: ' + err);
             return res.json(500, {error: 'Component was not updated due to ' + err});
           }
           return res.json(null);

--- a/routes/my.js
+++ b/routes/my.js
@@ -37,7 +37,7 @@ module.exports = function (mongoose, dbconn, makeAPIPublisher) {
 
       App.findOne({author:request.session.email, name: request.query.name}, function(err, obj) {
         if (!obj) {
-          console.error('Unable to find app for %s', request.query.name);
+          console.warn('Unable to find app for %s', request.query.name);
           return response.json(500, {error: 'Unable to find app: ' + err});
         } else {
           return response.json(obj);
@@ -89,14 +89,14 @@ module.exports = function (mongoose, dbconn, makeAPIPublisher) {
         var makeId = app['makeapi-id'];
         App.remove({author:request.session.email, name: request.body.name}, function(err) {
           if(err){
-            console.error("Error deleting this app!");
+            console.warn("Error deleting this app!");
             return response.json(500, {error: 'App was not deleted due to ' + err});
           }
           return response.json(200);
         });
         if (makeId) {
           makeAPIPublisher.remove(makeId, function(err) {
-            if (err) console.error("Error deleting make: " + err);
+            if (err) console.warn("Error deleting make: " + err);
           });
         }
       });
@@ -190,7 +190,7 @@ module.exports = function (mongoose, dbconn, makeAPIPublisher) {
 
       Component.remove({author:request.session.email, url: request.body.url}, function(err){
         if(err){
-          console.error("Error forgetting this component!");
+          console.warn("Error forgetting this component!");
           return response.json(500, {error: 'Component was not deleted due to ' + err});
         }
       });

--- a/routes/proxy.js
+++ b/routes/proxy.js
@@ -30,13 +30,13 @@ module.exports = {
 
     try {
       request.get(url).on('error',
-        function (err) { console.error('Error during remix proxy for ', url); })
+        function (err) { console.warn('Error during remix proxy for ', url); })
       .pipe(res)
       .on('error',
-        function (err) { console.error('Error during remix proxy for ', url); });
+        function (err) { console.warn('Error during remix proxy for ', url); });
     }
     catch (e) {
-      console.error('Error creating pipe for remix proxy', e);
+      console.warn('Error creating pipe for remix proxy', e);
       res.json({ message: 'No valid url.' }, 500);
       return;
     }
@@ -95,7 +95,7 @@ module.exports = {
         var newRequest = request.get(url);
 
         newRequest.on('error', function(err) {
-          console.error('error doing cors request for ', url);
+          console.warn('error doing cors request for ', url);
           res.json({error: 'No valid url (1).'}, 500);
         });
 
@@ -105,7 +105,7 @@ module.exports = {
           }
           else {
             newRequest.pipe(res).on('error', function(err) {
-              console.error('error doing piped cors request for ', url);
+              console.warn('error doing piped cors request for ', url);
               res.json({error: 'No valid url (2).'}, 500);
             });
           }

--- a/routes/publish.js
+++ b/routes/publish.js
@@ -26,7 +26,7 @@ module.exports = function (store, viewsPath, urlManager, makeAPIPublisher, dbcon
     var iconFilename = __dirname + '/../public/images/app-icon-' + iconSize + '.png';
     fs.readFile(iconFilename, function (err, iconData) {
       if (err) {
-        console.error('Could not load icon at ' + iconFilename + ' .');
+        console.warn('Could not load icon at ' + iconFilename + ' .');
       }
       else {
         icons[iconSize] = {
@@ -58,13 +58,13 @@ module.exports = function (store, viewsPath, urlManager, makeAPIPublisher, dbcon
     }
 
     if (! req.session.email) {
-      console.error('Need to be signed in to retrieve components.');
+      console.warn('Need to be signed in to retrieve components.');
       callback([]);
       return;
     }
     Component.find({author: req.session.email}, function (err, components) {
       if (err){
-        console.error('Unable to retrieve components.');
+        console.warn('Unable to retrieve components.');
         callback([]);
         return;
       }
@@ -193,7 +193,7 @@ module.exports = function (store, viewsPath, urlManager, makeAPIPublisher, dbcon
             }, {},
             function(err,obj){
               if(err){
-                console.error('Error saving published date to database: ' + err);
+                console.warn('Error saving published date to database: ' + err);
               }
             }
           );
@@ -201,7 +201,7 @@ module.exports = function (store, viewsPath, urlManager, makeAPIPublisher, dbcon
 
             store.write(description.filename, description.data, function (result) {
               if (200 !== result.statusCode) {
-                console.error('Trouble writing ' + description.filename + ' to S3 (' + result.statusCode + ').');
+                console.warn('Trouble writing ' + description.filename + ' to S3 (' + result.statusCode + ').');
               }
               if (++filesDone === outputFiles.length) {
                 res.json({error: null,
@@ -215,7 +215,7 @@ module.exports = function (store, viewsPath, urlManager, makeAPIPublisher, dbcon
                   name: inputData.name
                 }, function(err, app) {
                   if (err) {
-                    return console.error('Error finding app for publishing to MakeAPI: ' + err);
+                    return console.warn('Error finding app for publishing to MakeAPI: ' + err);
                   }
                   var id = app['makeapi-id'];
                   makeAPIPublisher.publish({
@@ -231,7 +231,7 @@ module.exports = function (store, viewsPath, urlManager, makeAPIPublisher, dbcon
                     locale: req.localeInfo.lang
                   }, function (err, make) {
                     if (err) {
-                      console.error(err);
+                      console.warn(err);
                     }
                     else if (!id) {
                       App.update({
@@ -242,7 +242,7 @@ module.exports = function (store, viewsPath, urlManager, makeAPIPublisher, dbcon
                       }, {},
                       function(err,obj){
                         if(err){
-                          console.error('Error saving MakeAPI id to database: ' + err);
+                          console.warn('Error saving MakeAPI id to database: ' + err);
                         }
                       });
                     }


### PR DESCRIPTION
The reasoning here is that ruby's foreman treats stderr data as "this process has crashed" rather than "this process is writing to stderr", and will kill it off. We're using console.error in quite a few places to signal errors before gracefully failing without crashing the server process, so that's really bad. This PR replaces all the `console.error` instances in our server-side code with `console.warn` instances instead, which don't crash Foreman. All instances of `console.error` in client-side code have been left untouched.

To verify that foreman is nuts, create a `Procfile` with content `web: node test.js` and a `test.js` file with content:

```
console.log("log");
console.info("info");
console.warn("warn");
console.error("error");
```

then run `node test` to verify you see all four console statements, and also run `foreman start` to see it echo the first three, and then exiting with code 8

Fixes #2102
