### PR TITLE
Fixed double button font size, color and padding - fixes #2014

### DIFF
--- a/public/bundles/components/component-double-button/component.css
+++ b/public/bundles/components/component-double-button/component.css
@@ -28,11 +28,13 @@
   padding: 12px 0px;
   text-overflow: ellipsis;
   overflow: hidden;
-  font-size: 1.8rem;
+  font-size: 18px;
   position: relative;
-  line-height: 1.8rem;
+  line-height: 18px;
   width: 100%;
+  font-family: inherit;
   display: block;
+  font-weight: 300;
   -webkit-box-sizing: border-box;
   width: calc(100% - 5px);
   border-radius: 3px;

--- a/public/bundles/components/component-double-button/component.html
+++ b/public/bundles/components/component-double-button/component.html
@@ -1,7 +1,7 @@
 <polymer-element name="ceci-double-button" attributes="playsound textcolor rightbuttoncolor leftbuttoncolor leftlabel rightlabel value" value="Click" extends="ceci-element"
   playsound="true"
   textcolor="#ffffff"
-  leftbuttoncolor="#4DB227"
+  leftbuttoncolor="#3fb58e"
   rightbuttoncolor="#bd400a">
   <ceci-definition>
     {


### PR DESCRIPTION
STT
- add a button
- add a double button
- publish the app
- on published app
  - green is same for both button and left button on double button
  - font size for all buttons is the same
  - padding for all buttons is the same
  - double button looks like the designer
