### PR TITLE
Fixed a few z-index issues, fixes #2120 and fixes #2091

### DIFF
--- a/public/bundles/components/component-double-button/component.css
+++ b/public/bundles/components/component-double-button/component.css
@@ -15,6 +15,7 @@
   width: 50%;
   line-height: 0px;
   font-size: 0px;
+  z-index: 1;
 }
 
 :host .buttons-wrapper {
@@ -50,12 +51,11 @@
   z-index: 3;
   background: rgba(0,0,0,.25);
   border-radius: 0 0 3px 3px;
-  z-index: 1;
 }
 
 :host .label {
   font-weight: 400;
-  z-index: 9999;
+  z-index: 4;
   position: absolute;
   top: 0px;
   left: 0px;

--- a/public/stylesheets/loading.css
+++ b/public/stylesheets/loading.css
@@ -9,6 +9,7 @@
   transition: opacity .4s ease-in .2s;
   top: 0;
   opacity: 1;
+  z-index: 9999;
 }
 
 .loading-pane.fade {


### PR DESCRIPTION
STS
- add a few double buttons
- publish app
- view /app of published app

Before - double button labels overlap black Appmaker loading screen 
After - double button labels overlap black Appmaker loading screen 
- open the Remix/Share panel 

Before - double button labels overlap the panel
After - double button don't overlap the panel
