### PR TITLE
Renamed button broadcast editable, fixes #2175

### DIFF
--- a/public/bundles/components/component-button/locale/en-US.json
+++ b/public/bundles/components/component-button/locale/en-US.json
@@ -5,7 +5,7 @@
 	"ceci-button/attributes/label/label": "Label",
 	"ceci-button/attributes/label/description": "Text shown on the button.",
 	"ceci-button/attributes/value": "Press",
-	"ceci-button/attributes/value/label": "Value",
+	"ceci-button/attributes/value/label": "Broadcast Value",
 	"ceci-button/attributes/value/description": "Value broadcast by the button when pressed.",
 	"ceci-button/attributes/textcolor/label": "Text Color",
 	"ceci-button/attributes/textcolor/description": "Color of the text on the button's label.",


### PR DESCRIPTION
STT:
- add a button brick
- look at the editable properties for it

Before: There is terribly named "Value" attribute <- what does it even do, bro?!
After: It is now called "Broadcast Value"
