### PR TITLE
Counter Updates - fixes #2152

### DIFF
--- a/public/bundles/components/component-counter/component.html
+++ b/public/bundles/components/component-counter/component.html
@@ -19,7 +19,7 @@ fontsize="16">
       "listeners": {
         "countUp": {
           "description": "Increment the total by the increment value",
-          "label": "Count Up!",
+          "label": "Count Up",
           "default" : true
         },
         "countDown": {
@@ -27,8 +27,8 @@ fontsize="16">
           "label": "Count Down"
         },
         "resetCount": {
-          "description": "Reset the total to 0.",
-          "label": "Reset Count"
+          "description": "Reset the count to the starting count.",
+          "label": "Reset to Starting Count"
         },
         "setValue": {
           "description": "Set the counter value to a specific number.",
@@ -52,8 +52,8 @@ fontsize="16">
           "min" : 1
         },
         "startingvalue": {
-          "description": "The starting value of the counter.",
-          "label": "Starting Value",
+          "description": "The starting count of the counter.",
+          "label": "Starting Count",
           "editable": "number",
           "min" : 1
         },
@@ -153,7 +153,7 @@ fontsize="16">
           this.value = Number(this.value) - Number(this.increment, 10);
         },
         resetCount: function() {
-          this.value = 0;
+          this.value = this.startingvalue;
         }
       });
     </script>


### PR DESCRIPTION
STT:
- add a counter brick
- it has a "Starting Count" editable (used to be called 'Starting Value')
- set it to 5
- add a button and link it to "Reset to Starting Count" , which used to be called "Reset Count"
- tap the counter a few times so that it increases beyond 5
- tap the button
- counter is set to 5
- Also, "Count Up" listener no longer has an exclamation after it "!" like it used to.

Question - does this break every app that relied on "Reset Count" setting the value to 0 instead of the starting value, does'n it? Do we care? What should we do?
