### PR TITLE
loop detection only, no user alert or intervention

### DIFF
--- a/public/ceci/ceci-element-base.html
+++ b/public/ceci/ceci-element-base.html
@@ -208,7 +208,7 @@
         this.localize = (function() {
 
           this.ceciDefinition = processDefinition(this);
- 
+
           var attributeResults = processAttributes(this.ceci.editables, this.ceciDefinition.attributes || {});
 
           Object.keys(attributeResults.attributeListeners).forEach(function (attributeName) {
@@ -307,52 +307,63 @@
           potentialCard.show();
         }
       },
+      getActiveListeners: function () {
+        return Array.prototype.slice.call(this.querySelectorAll("ceci-listen"));
+      },
       setListener: function (name, channel) {
         var entry = this.ceci.listeners[name];
 
         if (entry) {
           var listener = this.querySelector('ceci-listen[for="' + name + '"]');
+          var original = null;
           if (!listener) {
             listener = document.createElement('ceci-listen');
             this.appendChild(listener);
+            listener.setAttribute('for', name);
+          } else {
+             original = listener.on;
           }
-
           listener.setAttribute('on', channel);
-          listener.setAttribute('for', name);
-          this.fire('CeciChannelUpdated', {detail: {name: name, channel: channel, type: 'listen'}});
+          this.fire('CeciChannelUpdated', {detail: {name: name, channel: channel, type: 'listen', original: original}});
         }
         else {
           console.error('No listener definition found for "' + name + '".');
-        }
-      },
-      setBroadcast: function (name, channel) {
-        var entry = this.ceci.broadcasts[name];
-        if (entry) {
-          var broadcast = this.querySelector('ceci-broadcast[from="' + name + '"]');
-          if (!broadcast) {
-            broadcast = document.createElement('ceci-broadcast');
-            this.appendChild(broadcast);
-          }
-          broadcast.setAttribute('on', channel);
-          broadcast.setAttribute('from', name);
-          this.fire('CeciChannelUpdated', {detail: {name: name, channel: channel, type: 'broadcast'}});
-        }
-        else {
-          console.error('No broadcast definition found for "' + name + '".');
         }
       },
       removeListener: function (name) {
         var listen = this.querySelector('ceci-listen[for="' + name + '"]');
         if (listen) {
           this.removeChild(listen);
-          this.fire('CeciChannelUpdated', {detail: {name: name, channel: null, type: 'listen'}});
+          this.fire('CeciChannelUpdated', {detail: {name: name, channel: null, type: 'listen', original: listen.on}});
+        }
+      },
+      getActiveBroadcasts: function () {
+        return Array.prototype.slice.call(this.querySelectorAll("ceci-broadcast"));
+      },
+      setBroadcast: function (name, channel) {
+        var entry = this.ceci.broadcasts[name];
+        if (entry) {
+          var broadcast = this.querySelector('ceci-broadcast[from="' + name + '"]');
+          var original = null;
+          if (!broadcast) {
+            broadcast = document.createElement('ceci-broadcast');
+            this.appendChild(broadcast);
+            broadcast.setAttribute('from', name);
+          } else {
+            original = broadcast.on;
+          }
+          broadcast.setAttribute('on', channel);
+          this.fire('CeciChannelUpdated', {detail: {name: name, channel: channel, type: 'broadcast', original: original}});
+        }
+        else {
+          console.error('No broadcast definition found for "' + name + '".');
         }
       },
       removeBroadcast: function (name) {
         var broadcast = this.querySelector('ceci-broadcast[from="' + name + '"]');
         if (broadcast) {
           this.removeChild(broadcast);
-          this.fire('CeciChannelUpdated', {detail: {name: name, channel: null, type: 'broadcast'}});
+          this.fire('CeciChannelUpdated', {detail: {name: name, channel: null, type: 'broadcast', original: broadcast.on}});
         }
       },
       addCustomListener: function(el, listener){

--- a/public/designer/components/ceci-element-designer.html
+++ b/public/designer/components/ceci-element-designer.html
@@ -59,6 +59,7 @@
         var that = this;
         require(['designer/editable', 'analytics'], function (Editable, analytics) {
           Editable.removeAttributes();
+          document.dispatchEvent(new CustomEvent('CeciElementRemoved', {bubbles: true, detail: that}));
           analytics.event("Removed Component", { label: that.localName });
         });
       },

--- a/public/designer/js/channels.js
+++ b/public/designer/js/channels.js
@@ -3,20 +3,136 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define(
-  ["ceci/ceci-designer"],
-  function(Ceci) {
+  function() {
     "use strict";
 
-    Ceci.addChannels([
-      {id: 'blue',   name: 'Blue Moon',          hex: '#358CCE'},
-      {id: 'red',    name: 'Red Baloon',         hex: '#e81e1e'},
-      {id: 'pink',   name: 'Pink Heart',         hex: '#e3197b'},
-      {id: 'purple', name: 'Purple Horseshoe',   hex: '#9f27cf'},
-      {id: 'green',  name: 'Green Clover',       hex: '#71b806'},
-      {id: 'yellow', name: 'Yellow Pot of Gold', hex: '#e8d71e'},
-      {id: 'orange', name: 'Orange Star',        hex: '#ff7b00'},
-      {id: null,     name: 'Disabled',           hex: '#444'},
-    ]);
+    // internal map for tracking the connection graph for an app
+    var maps = {
+      listen: {},
+      broadcast: {}
+    };
+
+    /**
+     * generic FindLoop wrapper.
+     */
+    function findDirectionalLoop(channel, original, direction, seen) {
+      var tracker = (direction === "forward" ? maps.listen : maps.broadcast),
+          fn = (direction === "forward" ? "getActiveBroadcasts" : "getActiveListeners");
+      function FindLoop(channel) {
+        if(!channel) return false;
+        var paths = tracker[channel] || [],
+            next = [], node, i, j;
+        for(i=paths.length-1; i>=0; i--) {
+          node = paths[i];
+          if(node === original) { seen.push(node); return true; }
+          next = node[fn]();
+          for(j=next.length-1; j>=0; j--) {
+            node = next[j];
+            if (FindLoop(node.on)) { seen.push(node._element); return true; }
+          }
+        }
+        return false;
+      }
+      return FindLoop(channel);
+    }
+
+    /**
+     * User tells E to listen on channel X
+     *
+     * FindLoop(X) :=
+     * . for all broadcasters B for X:
+     *   . if B eq E => loop found
+     *   . else:
+     *     . for each B:
+     *       . for all listeners L with channel L.Y on B:
+     *         . FindLoop(L.Y)
+     */
+    function findListeningLoop(channel, original) {
+      var seen = [];
+      findDirectionalLoop(channel, original, "reverse", seen);
+      return (seen.length === 0 ? false : seen);
+    }
+
+    /**
+     * User tells E to broadcast on channel X
+     *
+     * FindLoop(X) :=
+     * . for all listeners L for X:
+     *   . if L eq E => loop found
+     *   . else:
+     *     . for each L:
+     *       . for all broadcasts B with channel B.Y on L:
+     *         . FindLoop(B.Y)
+     */
+    function findBroadcastingLoop(channel, original) {
+      var seen = [];
+      findDirectionalLoop(channel, original, "forward", seen);
+      return (seen.length === 0 ? false : seen.reverse());
+    }
+
+    /** Funnel to use the correct FindLoop algorithm
+     *
+     */
+    function findLoop(type, channel, element) {
+      if (type === "listen") {
+        return findListeningLoop(channel, element);
+      }
+      else if (type === "broadcast") {
+        return findBroadcastingLoop(channel, element);
+      }
+      return false;
+    }
+
+    /**
+     * When the "new app" button is pressed, we must make sure to clear the
+     * channel mappings, because they're no longer applicable.
+     */
+    window.addEventListener("resetcards", function clearMap(evt) {
+      maps = {
+        listen: {},
+        broadcast: {}
+      };
+    });
+
+    /**
+     * Remove an element's listen and broadcast records when it leaves the DOM
+     */
+    document.addEventListener("CeciElementRemoved", function forgetElement(evt) {
+      var element = evt.detail, map, pos;
+      Object.keys(maps).forEach(function(type) {
+        map = maps[type];
+        Object.keys(map).forEach(function(channel) {
+          pos = map[channel].indexOf(element);
+          if(pos > -1) {
+            map[channel].splice(pos, 1);
+          }
+        });
+      });
+    });
+
+    /**
+     * Chronicle an element/channel binding when a channel update occurs
+     */
+    window.addEventListener("CeciChannelUpdated", function buildConnectionGraph(evt) {
+      var element = evt.target,
+          data = evt.detail.detail,
+          name = data.name,
+          type = data.type,
+          channel = data.channel,
+          original = data.original,
+          map = maps[type];
+
+      if (!map[channel]) map[channel] = [];
+      if (original) {
+        var pos = map[original].indexOf(element);
+        map[original].splice(pos,1);
+      }
+      if(channel) {
+        var loop = findLoop(type, channel, element);
+        if (loop) { console.warn("Warning: possible loop established. Element chain:", loop); }
+        map[channel].push(element);
+      }
+    });
 
   }
 );


### PR DESCRIPTION
Rebase and PR-fixes stemming from #2148, addresses #1075 

STR: create a two-counter app, make counter 1 listen on A and broadcast B, make the second counter listen to B and broadcast A. The console will report a possible loop has been detected, both when you close the loop by setting the listener last, or setting the broadcast last.
