### PR TITLE
Text Brick font fix - fixes #2912

### DIFF
--- a/public/bundles/components/component-textbox/component.css
+++ b/public/bundles/components/component-textbox/component.css
@@ -10,7 +10,6 @@
   white-space: pre-wrap;
   overflow: hidden;
   margin: 0;
-  font-family: "FiraSans", sans-serif;
   font-weight: 500;
   line-height: auto;
 }


### PR DESCRIPTION
Removed the font family declaration from the text brick so that it matches other bricks.

STT
- add a counter
- add a text box

Before: font is different between those two.
After: font is the same
