### PR TITLE
shimmed NodeList with an array() function

### DIFF
--- a/public/ceci/ceci-element-base.html
+++ b/public/ceci/ceci-element-base.html
@@ -9,6 +9,9 @@
 
   <!-- base functions and globals -->
   <script>
+    // making things easier for devs of all walks of life
+    if(!NodeList.prototype.array) { NodeList.prototype.array = Array.prototype.slice; }
+
     var DEFAULT_CHANNEL = 'blue';
 
     // Mouse/touch events that need to be routed properly

--- a/public/designer/js/index.js
+++ b/public/designer/js/index.js
@@ -21,6 +21,11 @@ define(
   function(l10n, Inflector, Utils, Ceci, Intro) {
     "use strict";
 
+    // making things easier for devs of all walks of life
+    if(!NodeList.prototype.array) {
+      NodeList.prototype.array = Array.prototype.slice;
+    }
+
     function onPolymerReadyForIntro() {
       // make sure we have a ceci-app available
       var ceciApp = document.querySelector("ceci-app");


### PR DESCRIPTION
Fixes #2186 

This will let us just do `document.querySelectorAll(...).array().forEach` instead of `Array.prototype.slice.call(document.querySelectorAll(...)).forEach`

Docs over at https://github.com/mozilla-appmaker/appmaker/wiki/Appmaker-Architectural-Draft#code-helpers
