### PR TITLE
Changed Image Brick broadcast label from "Click" to "Image".

### DIFF
--- a/public/bundles/components/component-image/component.html
+++ b/public/bundles/components/component-image/component.html
@@ -15,7 +15,7 @@
       "description": "Displays an image using a simple web URL or data-uri.",
       "broadcasts": {
         "click": {
-          "label": "Click",
+          "label": "Image",
           "description": "Occurs when the image is clicked.",
           "default": false
         }


### PR DESCRIPTION
STR
- Add an Image
- Open its broadcast menu

Before - it has a Click broadcast.
After - it has an Image broadcast.
