### PR TITLE
Expand handle missing bug fix - fixes #2128

### DIFF
--- a/views/designerHTML.ejs
+++ b/views/designerHTML.ejs
@@ -22,9 +22,8 @@
       <div id="category-description"></div>
       <div id="components"></div>
     </div>
-
-    <div class="expand-handle expand-right"></div>
   </div>
+  <div class="expand-handle expand-right"></div>
   <div class="right-column">
     <div class="editable-section">
       <div class="tray-tabs">


### PR DESCRIPTION
STT
- collapse the tray

Before: right tray 'collapse arrow' is missing
After: right tray has a 'collapse arrow' and is collapsable
