### PR TITLE
Text align left as default for app - fixes #2247

### DIFF
--- a/public/ceci/ceci-app.html
+++ b/public/ceci/ceci-app.html
@@ -7,6 +7,7 @@
         width: 100%;
         background: #fff;
         height: 100%;
+        text-align: left;
       }
     </style>
     <content></content>


### PR DESCRIPTION
STT
- Add a text-input brick
- Publish the app
- Text input looks same in designer and published app

Note: there are some font inconsistencies that are a bigger issue that I'll address later.
