### PR TITLE
List Display Bug Fix - fixes #2255

### DIFF
--- a/public/bundles/components/component-list/component.css
+++ b/public/bundles/components/component-list/component.css
@@ -20,11 +20,9 @@
 
 :host .item {
   padding: 10px 0;
+  min-height: 22px;
 }
 
-:host .item:empty:after {
-  content: "\00a0";
-}
 
 :host .item-wrapper:last-child {
   border: none;

--- a/public/bundles/components/component-list/component.html
+++ b/public/bundles/components/component-list/component.html
@@ -123,6 +123,7 @@
           this.collection = this.shadowRoot.querySelector(".first-run-container input").value;
         },
         additem: function(item) {
+          item = item.trim();
           if(item){
             var collection = this.collections.getCollection(this.collection);
             collection.addItem({


### PR DESCRIPTION
STT
- Add a List brick
- Add some items
- Make one of the items blank via the collections editor

Before: Empty list item height collapses and breaks styling
After: Empty list item stays same height as before
