### PR TITLE
Channel vis ordering fix

### DIFF
--- a/public/designer/components/ceci-channel-vis.html
+++ b/public/designer/components/ceci-channel-vis.html
@@ -8,6 +8,8 @@
       attached: function () {
         this.component = this.parentNode;
         this.component.addEventListener('CeciChannelUpdated', this.updateChannelVis.bind(this));
+      },
+      domReady : function(){
         this.updateChannelVis();
       },
       updateChannelVis: function() {
@@ -22,7 +24,6 @@
         }
 
         elements = elements.array();
-      
         // Remove all existing channel lines
         var existingLines = this.lines;
         existingLines.innerHTML = "";
@@ -45,8 +46,6 @@
           el.addEventListener('signalFired', function(data){
             that.fire(data);
           });
-
-
 
           var channel = document.createElement("div");
 


### PR DESCRIPTION
STT
- Add a Counter brick
- Configure the channels like this 
  ![image](https://cloud.githubusercontent.com/assets/25212/4365282/163ed804-42ab-11e4-9c1e-79feada7da90.png)
- Save the app
- Refresh the designer

Before: Channel vis lines appear in a different order than the menu
After: Channel vis lines appear in the correct order

See #2129 for more detail. Fixes #2129
