### PR TITLE
Switching to "Brick" tab when appropriate

### DIFF
--- a/public/designer/js/editable.js
+++ b/public/designer/js/editable.js
@@ -229,7 +229,8 @@ define(['jquery', 'inflector', 'l10n', 'colorpicker.core'], function ($, Inflect
       $('.section-customize').hide();
     },
     displayAttributes: function (element) {
-      $('.section-customize').show();
+      window.dispatchEvent(new CustomEvent("change-tray-tab", { detail: { tab: "customize"}}));
+
       $('.editable-header > .name').text(element.ceci.name);
 
       var description = L10n.get(element.localName + '/description') || element.ceci.description;

--- a/public/designer/js/modes.js
+++ b/public/designer/js/modes.js
@@ -31,6 +31,10 @@ define(
       return false;
     });
 
+    window.addEventListener("change-tray-tab", function(e){
+      changeEditableTab(e.detail.tab);
+    });
+
     function changeEditableTab(tab) {
       $(".tray-tabs").find("a").removeClass("selected-tab");
       $(".tray-tabs [tab='"+tab+"']").addClass("selected-tab");

--- a/public/designer/js/mutant.js
+++ b/public/designer/js/mutant.js
@@ -40,6 +40,7 @@ define(
 
     function selectElement(element){
       if (element.classList.contains("selected")) {
+        window.dispatchEvent(new CustomEvent("change-tray-tab", { detail: { tab: "customize"}}));
         return;
       }
       unselectElements();


### PR DESCRIPTION
STT
- Switch to the Project tab
- Add a Brick

Before: Brick editables are displayed in Project tab
After: Designer switches to the Brick tab and shows the editable properties there

Fixes #2274
