### PR TITLE
don't refresh 'my' things when not logged in

### DIFF
--- a/public/designer/components/user-state.html
+++ b/public/designer/components/user-state.html
@@ -732,7 +732,9 @@
         refreshAppList: function(currentApp) {
           var self = this;
 
-          if (user.state === "signedout") return;
+          if (user.state === "signedout") {
+            return;
+          }
 
           var myApps = this.shadowRoot.querySelector("#myapps");
           var noApps = this.shadowRoot.querySelector("#noApps");
@@ -792,9 +794,9 @@
           });
         },
         refreshComponentsList: function() {
-          if(!this.customcomponents) { return; }
-
-          if (user.state === "signedout") return;
+          if(!this.customcomponents || user.state === "signedout") {
+            return;
+          }
 
           var self = this;
           var myComponents = this.shadowRoot.querySelector("#mycomponents");


### PR DESCRIPTION
Fixes #2094 - STR: make sure you're logged out, hit "new app" button. On dev: jquery errors because you're not logged in by trying to get `/my/` things. In this patch: no more jquery errors.
