### PR TITLE
Brick selecting fix

### DIFF
--- a/public/bundles/components/component-alternating-gate/component.html
+++ b/public/bundles/components/component-alternating-gate/component.html
@@ -1,4 +1,4 @@
-<polymer-element name="ceci-alternating-gate" attributes="countbeforeswitch" extends="ceci-element">
+<polymer-element name="ceci-alternating-gate" attributes="countbeforeswitch" extends="ceci-element" countbeforeswitch="1">
   <template>
     <link rel="stylesheet" href="component.css"></link>
     <div id="channels"></div>
@@ -55,16 +55,16 @@
     Polymer('ceci-alternating-gate', {
       nextBroadcast : "",
       ready: function() {
+        this.super();
         this.countbeforeswitch = Number(this.countbeforeswitch) || 1;
         this.lastBroadcast = null;
         this.count = 0;
-        this.super();
       },
-      countbeforeswitch: 1,
       attached : function(){
         this.super();
       },
       domReady: function() {
+        this.super();
         var that = this;
         this.onChannelUpdate = function(){
           that.updateChannels();

--- a/public/bundles/components/component-channel-gate/component.html
+++ b/public/bundles/components/component-channel-gate/component.html
@@ -55,6 +55,7 @@
         this.super();
       },
       domReady: function() {
+        this.super();
         var that = this;
         this.onChannelUpdate = function(){
           that.updateChannels();


### PR DESCRIPTION
STT
- Add a Chanel Gate brick and an Alternating Gate brick
- Click back and forth between them

Before: Once these bricks stop being selected, they can no longer be selected by clicking
After: Bricks become selected when clicked
