### PR TITLE
explicit this binding

### DIFF
--- a/public/ceci/ceci-element-base.html
+++ b/public/ceci/ceci-element-base.html
@@ -263,6 +263,7 @@
        * or once the element finishes its initialisation an CeciElementReady get fired off.
        */
       onready: function(fn) {
+        fn = fn.bind(this);
         if(this.elementReady) { fn(); }
         else {
           this.addEventListener('CeciElementReady', fn);


### PR DESCRIPTION
Fixes #2307 although it more "addresses" than "fixes" since nothing was broken. This binds the context for the onready function to always be the element itself (as event listener that already happens, but the direct call we have in place most certain doesn't). So now the `this` inside the function will always be the element itself.
