### PR TITLE
uuid fix for browserify bundling

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function( grunt ) {
     pkg: grunt.file.readJSON( "package.json" ),
     simplemocha: {
       options: {
-        timeout: 3000,
+        timeout: 30000,
         ignoreLeaks: true,
         ui: 'bdd',
         reporter: 'spec'

--- a/node_modules/vendor/uuid.js
+++ b/node_modules/vendor/uuid.js
@@ -1,0 +1,30 @@
+module.exports = (function() {
+  // This returns a Version 4 (random) UUID
+  // See: https://en.wikipedia.org/wiki/Universally_unique_identifier for more info
+
+  function hex(length) {
+    if (length > 8) return hex(8) + hex(length-8); // routine is good for up to 8 digits
+    var myHex = Math.random().toString(16).slice(2,2+length);
+    return pad(myHex, length); // just in case we don't get 8 digits for some reason
+  }
+
+  function pad(str, length) {
+    while(str.length < length){
+      str += '0';
+    }
+    return str;
+  }
+
+  function variant() {
+    return '89ab'[Math.floor(Math.random() * 4)];
+  }
+
+  // Public interface
+  function uuid() {
+    return hex(8) + '-' + hex(4) + '-4' + hex(3) + '-' + variant() + hex(3) + '-' + hex(12);
+  }
+
+  return uuid;
+
+}());
+

--- a/public/designer/js/application.js
+++ b/public/designer/js/application.js
@@ -7,9 +7,7 @@ var l10n = require('vendor/l10n');
 var reporter = require('vendor/reporter');
 var Editable = require('./editable');
 var publishPane = require('./publishPane');
-
-// TODO: should explicitly require this instead of relying on global.
-var uuid = window.uuid;
+var uuid = require('vendor/uuid');
 
 var localStorage = window.localStorage;
 var location = window.location;


### PR DESCRIPTION
fixes #2365 by fxing the uuid call failing. also fixes grunt so that it passes appmaker even if it takes more than 3 seconds to fully initialize, which may be necessary for grunt testing this fix (seen travis fail due to timeout before)
